### PR TITLE
issue # 7  fix to be able to test system-users.

### DIFF
--- a/accesscontrolvalidator-bundle/src/main/java/biz/netcentric/aem/tools/acvalidator/serviceuser/ServiceResourceResolverService.java
+++ b/accesscontrolvalidator-bundle/src/main/java/biz/netcentric/aem/tools/acvalidator/serviceuser/ServiceResourceResolverService.java
@@ -29,7 +29,10 @@ public interface ServiceResourceResolverService {
 	 * @throws LoginException error getting resource resolver
 	 */
 	ResourceResolver getServiceResourceResolver() throws LoginException;
-	
+
+	ResourceResolver getServiceResourceResolver(String authorizableID) throws LoginException;
+
+
 	Session getUserSession(SimpleCredentials credentials) throws javax.jcr.LoginException, RepositoryException;
 
 

--- a/accesscontrolvalidator-bundle/src/main/java/biz/netcentric/aem/tools/acvalidator/serviceuser/ServiceResourceResolverServiceImpl.java
+++ b/accesscontrolvalidator-bundle/src/main/java/biz/netcentric/aem/tools/acvalidator/serviceuser/ServiceResourceResolverServiceImpl.java
@@ -47,6 +47,13 @@ public class ServiceResourceResolverServiceImpl implements ServiceResourceResolv
 	}
 
 	@Override
+	public ResourceResolver getServiceResourceResolver(String authorizableID) throws LoginException {
+		final Map<String, Object> authenticationInfo = new HashMap<>();
+		authenticationInfo.put(ResourceResolverFactory.SUBSERVICE, authorizableID);
+		return resourceResolverFactory.getServiceResourceResolver(authenticationInfo);
+	}
+
+	@Override
 	public Session getUserSession(SimpleCredentials credentials) throws javax.jcr.LoginException, RepositoryException {
 		javax.jcr.Session session = repository.login(credentials);
 		return session;


### PR DESCRIPTION
Requires OSGI config with service mapping for bundle
'biz.netcentric.aem.tools.accesscontrolvalidator.bundle'
Service name in this config should be equal to system user id.